### PR TITLE
chore: Fix cargo version for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "korrosync"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "argon2",
  "assert_cmd",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps `korrosync` crate version to `0.1.1` in `Cargo.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e9a10f91b315bfd1e43f448d132aa1178f4e187. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->