### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/szaffarano/korrosync/compare/v0.1.1...v0.1.2) - 2025-11-14
+
+### Added
+
+- *(renovate)* Add zig to renovate config ([#26](https://github.com/szaffarano/korrosync/pull/26))
+
+### Other
+
+- Improve error handling ([#32](https://github.com/szaffarano/korrosync/pull/32))
+- *(deps)* update rust crate governor to v0.10.2 ([#29](https://github.com/szaffarano/korrosync/pull/29))
+- Improve coverage ([#31](https://github.com/szaffarano/korrosync/pull/31))
+- *(deps)* update rust crate tokio-retry2 to 0.7.0 ([#30](https://github.com/szaffarano/korrosync/pull/30))
+- *(deps)* update dependency ziglang/zig to v0.15.1 ([#27](https://github.com/szaffarano/korrosync/pull/27))
+
 ## [0.1.1](https://github.com/szaffarano/korrosync/releases/tag/v0.1.0) - 2025-11-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "korrosync"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "argon2",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "korrosync"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["Sebastián Zaffarano <sebastian.zaffarano@elastic.co>"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `korrosync`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/szaffarano/korrosync/compare/v0.1.1...v0.1.2) - 2025-11-14

### Added

- *(renovate)* Add zig to renovate config ([#26](https://github.com/szaffarano/korrosync/pull/26))

### Other

- Improve error handling ([#32](https://github.com/szaffarano/korrosync/pull/32))
- *(deps)* update rust crate governor to v0.10.2 ([#29](https://github.com/szaffarano/korrosync/pull/29))
- Improve coverage ([#31](https://github.com/szaffarano/korrosync/pull/31))
- *(deps)* update rust crate tokio-retry2 to 0.7.0 ([#30](https://github.com/szaffarano/korrosync/pull/30))
- *(deps)* update dependency ziglang/zig to v0.15.1 ([#27](https://github.com/szaffarano/korrosync/pull/27))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps crate to 0.1.2 and updates CHANGELOG with release notes.
> 
> - **Release**:
>   - Bump version to `0.1.2` in `Cargo.toml` and `Cargo.lock`.
> - **Docs**:
>   - Update `CHANGELOG.md` with 0.1.2 notes (additions, dependency updates, and improvements).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f0dd57f1deac1d4932a219737d44882bcf3e5b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->