### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/szaffarano/korrosync/compare/v0.1.3...v0.1.4) - 2025-11-16
+
+### Added
+
+- *(docker)* Publish on release
+
+### Fixed
+
+- *(docker)* Update tag resolution
+
+### Other
+
+- *(deps)* update docker/login-action digest to 28fdb31 ([#37](https://github.com/szaffarano/korrosync/pull/37))
+- *(deps)* update docker/build-push-action digest to 9e436ba ([#36](https://github.com/szaffarano/korrosync/pull/36))
+- *(deps)* update docker/metadata-action digest to 8d8c7c1 ([#40](https://github.com/szaffarano/korrosync/pull/40))
+- *(ci)* Cleanup workflow definition ([#39](https://github.com/szaffarano/korrosync/pull/39))
+
 ## [0.1.3](https://github.com/szaffarano/korrosync/compare/v0.1.2...v0.1.3) - 2025-11-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "korrosync"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "argon2",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "korrosync"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 authors = ["Sebastián Zaffarano <sebastian.zaffarano@elastic.co>"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `korrosync`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/szaffarano/korrosync/compare/v0.1.3...v0.1.4) - 2025-11-16

### Added

- *(docker)* Publish on release

### Fixed

- *(docker)* Update tag resolution

### Other

- *(deps)* update docker/login-action digest to 28fdb31 ([#37](https://github.com/szaffarano/korrosync/pull/37))
- *(deps)* update docker/build-push-action digest to 9e436ba ([#36](https://github.com/szaffarano/korrosync/pull/36))
- *(deps)* update docker/metadata-action digest to 8d8c7c1 ([#40](https://github.com/szaffarano/korrosync/pull/40))
- *(ci)* Cleanup workflow definition ([#39](https://github.com/szaffarano/korrosync/pull/39))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps crate to 0.1.4 and updates CHANGELOG with docker release notes, fixes, deps digests, and CI cleanup.
> 
> - **Release**:
>   - Bump `korrosync` version to `0.1.4` in `Cargo.toml` and `Cargo.lock`.
> - **Changelog**:
>   - Add `0.1.4` entry: docker publish on release, tag resolution fix, updated docker action digests, and CI workflow cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4ac8f734ebda0a9e45d3e6d5b8910b5f441d6a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->