### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/szaffarano/korrosync/compare/v0.3.0...v0.4.0) - 2026-02-14
+
+### Added
+
+- make rate limiting configurable via environment variables ([#91](https://github.com/szaffarano/korrosync/pull/91))
+
+### Other
+
+- Add agents.md ([#90](https://github.com/szaffarano/korrosync/pull/90))
+
 ## [0.3.0](https://github.com/szaffarano/korrosync/compare/v0.2.1...v0.3.0) - 2026-02-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/szaffarano/korrosync/compare/v0.3.0...v0.4.0) - 2026-05-14
+
+### Added
+
+- make rate limiting configurable via environment variables ([#91](https://github.com/szaffarano/korrosync/pull/91))
+
+### Other
+
+- *(deps)* update rust crate uuid to v1.23.1 ([#109](https://github.com/szaffarano/korrosync/pull/109))
+- *(deps)* update codecov/codecov-action action to v6 ([#110](https://github.com/szaffarano/korrosync/pull/110))
+- *(deps)* update rust crate reqwest to v0.13.3 ([#107](https://github.com/szaffarano/korrosync/pull/107))
+- *(deps)* update rust crate tower-http to v0.6.10 ([#108](https://github.com/szaffarano/korrosync/pull/108))
+- *(deps)* update rust crate serial_test to v3.4.0 ([#93](https://github.com/szaffarano/korrosync/pull/93))
+- *(deps)* update axum monorepo ([#106](https://github.com/szaffarano/korrosync/pull/106))
+- *(deps)* update rust crate assert_cmd to v2.2.2 ([#104](https://github.com/szaffarano/korrosync/pull/104))
+- *(deps)* update rust crate tracing-subscriber to v0.3.23 ([#103](https://github.com/szaffarano/korrosync/pull/103))
+- *(deps)* update rust crate redb to v3.1.3 ([#102](https://github.com/szaffarano/korrosync/pull/102))
+- *(deps)* update docker/setup-qemu-action action to v4 ([#101](https://github.com/szaffarano/korrosync/pull/101))
+- *(deps)* update rust crate tokio to v1.52.3 ([#97](https://github.com/szaffarano/korrosync/pull/97))
+- *(deps)* update rust crate tempfile to v3.27.0 ([#95](https://github.com/szaffarano/korrosync/pull/95))
+- *(deps)* update rust crate chrono to v0.4.44 ([#94](https://github.com/szaffarano/korrosync/pull/94))
+- *(deps)* update rust crate clap to v4.6.1 ([#92](https://github.com/szaffarano/korrosync/pull/92))
+- Update deps ([#105](https://github.com/szaffarano/korrosync/pull/105))
+- *(deps)* update actions/upload-artifact action to v7 ([#96](https://github.com/szaffarano/korrosync/pull/96))
+- Add agents.md ([#90](https://github.com/szaffarano/korrosync/pull/90))
+
 ## [0.3.0](https://github.com/szaffarano/korrosync/compare/v0.2.1...v0.3.0) - 2026-02-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,7 +1347,7 @@ dependencies = [
 
 [[package]]
 name = "korrosync"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "argon2",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "korrosync"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "argon2",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "korrosync"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors = ["Sebastián Zaffarano <sebastian.zaffarano@elastic.co>"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `korrosync`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `korrosync` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Config.rate_limit in /tmp/.tmpnXmih0/korrosync/src/config.rs:47

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_parameter_count_changed.ron

Failed in:
  korrosync::api::middleware::ratelimiter::rate_limiter_layer now takes 2 parameters instead of 1, in /tmp/.tmpnXmih0/korrosync/src/api/middleware/ratelimiter.rs:12
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/szaffarano/korrosync/compare/v0.3.0...v0.4.0) - 2026-05-14

### Added

- make rate limiting configurable via environment variables ([#91](https://github.com/szaffarano/korrosync/pull/91))

### Other

- *(deps)* update rust crate uuid to v1.23.1 ([#109](https://github.com/szaffarano/korrosync/pull/109))
- *(deps)* update codecov/codecov-action action to v6 ([#110](https://github.com/szaffarano/korrosync/pull/110))
- *(deps)* update rust crate reqwest to v0.13.3 ([#107](https://github.com/szaffarano/korrosync/pull/107))
- *(deps)* update rust crate tower-http to v0.6.10 ([#108](https://github.com/szaffarano/korrosync/pull/108))
- *(deps)* update rust crate serial_test to v3.4.0 ([#93](https://github.com/szaffarano/korrosync/pull/93))
- *(deps)* update axum monorepo ([#106](https://github.com/szaffarano/korrosync/pull/106))
- *(deps)* update rust crate assert_cmd to v2.2.2 ([#104](https://github.com/szaffarano/korrosync/pull/104))
- *(deps)* update rust crate tracing-subscriber to v0.3.23 ([#103](https://github.com/szaffarano/korrosync/pull/103))
- *(deps)* update rust crate redb to v3.1.3 ([#102](https://github.com/szaffarano/korrosync/pull/102))
- *(deps)* update docker/setup-qemu-action action to v4 ([#101](https://github.com/szaffarano/korrosync/pull/101))
- *(deps)* update rust crate tokio to v1.52.3 ([#97](https://github.com/szaffarano/korrosync/pull/97))
- *(deps)* update rust crate tempfile to v3.27.0 ([#95](https://github.com/szaffarano/korrosync/pull/95))
- *(deps)* update rust crate chrono to v0.4.44 ([#94](https://github.com/szaffarano/korrosync/pull/94))
- *(deps)* update rust crate clap to v4.6.1 ([#92](https://github.com/szaffarano/korrosync/pull/92))
- Update deps ([#105](https://github.com/szaffarano/korrosync/pull/105))
- *(deps)* update actions/upload-artifact action to v7 ([#96](https://github.com/szaffarano/korrosync/pull/96))
- Add agents.md ([#90](https://github.com/szaffarano/korrosync/pull/90))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates release metadata (version bumps and changelog) and does not modify runtime code paths.
> 
> **Overview**
> Prepares the `v0.4.0` release by bumping the crate version from `0.3.0` to `0.4.0` in `Cargo.toml`/`Cargo.lock`.
> 
> Updates `CHANGELOG.md` with the new `0.4.0` section (noting configurable rate limiting and dependency updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26069de5fad06a9db2c1f2b5990c0900fddbd5f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->