### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/szaffarano/korrosync/compare/v0.4.0...v0.4.1) - 2026-05-29
+
+### Fixed
+
+- *(deps)* update rust crate redb to v4 ([#112](https://github.com/szaffarano/korrosync/pull/112))
+
+### Other
+
+- *(deps)* update docker/setup-buildx-action action to v4 ([#111](https://github.com/szaffarano/korrosync/pull/111))
+- *(deps)* update rust crate reqwest to v0.13.4 ([#117](https://github.com/szaffarano/korrosync/pull/117))
+
 ## [0.4.0](https://github.com/szaffarano/korrosync/compare/v0.3.0...v0.4.0) - 2026-05-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "korrosync"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "argon2",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "korrosync"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["Sebastián Zaffarano <sebastian.zaffarano@elastic.co>"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `korrosync`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/szaffarano/korrosync/compare/v0.4.0...v0.4.1) - 2026-05-29

### Fixed

- *(deps)* update rust crate redb to v4 ([#112](https://github.com/szaffarano/korrosync/pull/112))

### Other

- *(deps)* update docker/setup-buildx-action action to v4 ([#111](https://github.com/szaffarano/korrosync/pull/111))
- *(deps)* update rust crate reqwest to v0.13.4 ([#117](https://github.com/szaffarano/korrosync/pull/117))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).