### PR TITLE
fix: accounts created via CLI can't authenticate with real kosync clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -332,6 +332,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -516,6 +525,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +582,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,9 +616,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -642,7 +677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -998,6 +1033,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,6 +1342,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "governor",
+ "md-5",
  "redb",
  "reqwest",
  "rkyv",
@@ -1383,6 +1428,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "memchr"
@@ -1968,7 +2023,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2025,7 +2080,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2375,7 +2430,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2706,9 +2761,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -2970,7 +3025,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ rkyv = { version = "0.8.15", features = ["alloc", "bytecheck", "unaligned"] }
 chrono = "0.4.42"
 color-eyre = "0.6.5"
 governor = "0.10"
+md-5 = "0.11.0"
 redb = "4.0.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use color_eyre::eyre::{self, Context};
 use korrosync::cli::{Cli, Commands, DbCommands, UserCommands};
 use korrosync::config::Config;
-use korrosync::model::User;
+use korrosync::model::{User, md5_hex};
 use korrosync::service::db::{KorrosyncService, KorrosyncServiceRedb};
 
 #[tokio::main]
@@ -28,7 +28,9 @@ async fn main() -> eyre::Result<()> {
             match cmd {
                 UserCommands::Create { username, password } => {
                     let password = resolve_password(password)?;
-                    let user = User::new(&username, &password)
+                    // kosync clients MD5-hash the password before ever sending it, so the CLI
+                    // must apply the same step to match what a real client will present at login.
+                    let user = User::new(&username, md5_hex(&password))
                         .map_err(|e| eyre::eyre!("Failed to create user: {}", e))?;
                     service
                         .create_or_update_user(user)
@@ -74,7 +76,7 @@ async fn main() -> eyre::Result<()> {
                     if existing.is_none() {
                         eyre::bail!("User '{}' not found", username);
                     }
-                    let user = User::new(&username, &password)
+                    let user = User::new(&username, md5_hex(&password))
                         .map_err(|e| eyre::eyre!("Failed to hash password: {}", e))?;
                     service
                         .create_or_update_user(user)

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -42,4 +42,4 @@ mod user;
 
 pub use error::Error;
 pub use progress::Progress;
-pub use user::User;
+pub use user::{User, md5_hex};

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -29,9 +29,29 @@ use argon2::{
     },
 };
 use chrono::Utc;
+use md5::{Digest, Md5};
 use rkyv::{Archive, Deserialize, Serialize};
 
 use crate::model::error::Error;
+
+/// Computes the MD5 hex digest of a password, matching what real kosync clients (KOReader,
+/// CrossPoint, etc.) always compute client-side and send as the password/x-auth-key value.
+///
+/// The kosync protocol never sends the plain-text password over the wire: clients MD5-hash it
+/// first, both at registration and at login. The server therefore never sees, and never expects
+/// to see, the literal password — only this digest is meaningful input to [`User::new`] and
+/// [`User::check`]. Any caller that starts from a real plain-text password (e.g. the CLI, which
+/// takes one directly from an admin) must run it through this function first so the stored
+/// credential matches what clients will present later.
+pub fn md5_hex(password: impl AsRef<[u8]>) -> String {
+    let mut hasher = Md5::new();
+    hasher.update(password.as_ref());
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
 
 /// User model representing an authenticated user in the system.
 ///
@@ -330,6 +350,22 @@ mod tests {
             (now - activity).abs() < 1000,
             "touch() should set timestamp to current time (within 1 second)"
         );
+    }
+
+    #[test]
+    fn test_md5_hex_matches_known_digest() {
+        // Known-answer test vector from RFC 1321.
+        assert_eq!(md5_hex("abc"), "900150983cd24fb0d6963f7d28e17f72");
+    }
+
+    #[test]
+    fn test_md5_hex_is_deterministic() {
+        assert_eq!(md5_hex("same_password"), md5_hex("same_password"));
+    }
+
+    #[test]
+    fn test_md5_hex_differs_for_different_input() {
+        assert_ne!(md5_hex("password_a"), md5_hex("password_b"));
     }
 
     #[test]

--- a/tests/user_cli_password_test.rs
+++ b/tests/user_cli_password_test.rs
@@ -1,0 +1,175 @@
+//! Regression tests for the CLI/API password consistency bug: accounts created with
+//! `korrosync user create`/`user reset-password` must authenticate with the MD5-hashed
+//! credential that real kosync clients (KOReader, CrossPoint, etc.) send as `x-auth-key`,
+//! not with the raw plain-text password typed by the admin.
+
+mod common;
+
+use std::sync::Arc;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use axum::http::StatusCode;
+use common::{AuthenticatedRequestBuilder, UnauthenticatedRequestBuilder};
+use korrosync::api::{router::app, state::AppState};
+use korrosync::model::md5_hex;
+use korrosync::service::db::KorrosyncServiceRedb;
+use tempfile::NamedTempFile;
+use tower::ServiceExt;
+
+/// Runs `korrosync user create` against `db_path` and asserts it succeeded.
+fn cli_create_user(db_path: &str, username: &str, password: &str) {
+    cargo_bin_cmd!("korrosync")
+        .args([
+            "--db-path",
+            db_path,
+            "user",
+            "create",
+            "--username",
+            username,
+            "--password",
+            password,
+        ])
+        .assert()
+        .success();
+}
+
+#[tokio::test]
+async fn cli_created_user_authenticates_with_md5_hashed_password() {
+    let db_path = NamedTempFile::new().expect("Creating temp file");
+    let db_path = db_path.path().to_string_lossy().to_string();
+    let real_password = "correct horse battery staple";
+
+    cli_create_user(&db_path, "alice", real_password);
+
+    let sync = Arc::new(
+        KorrosyncServiceRedb::new(&db_path).expect("Failed to open database created by the CLI"),
+    );
+    let app = app(AppState { sync });
+
+    // A real kosync client never sends the plain-text password: it MD5-hashes it first.
+    let response = app
+        .clone()
+        .oneshot(
+            AuthenticatedRequestBuilder::get("/users/auth")
+                .credentials("alice", &md5_hex(real_password))
+                .build(),
+        )
+        .await
+        .expect("Failed to send request");
+    assert_eq!(
+        StatusCode::OK,
+        response.status(),
+        "user created via the CLI must authenticate with the MD5-hashed password a real client sends"
+    );
+
+    // The raw plain-text password must NOT work as the x-auth-key, since no real client ever
+    // sends it that way.
+    let response = app
+        .oneshot(
+            AuthenticatedRequestBuilder::get("/users/auth")
+                .credentials("alice", real_password)
+                .build(),
+        )
+        .await
+        .expect("Failed to send request");
+    assert_eq!(StatusCode::UNAUTHORIZED, response.status());
+}
+
+#[tokio::test]
+async fn cli_reset_password_authenticates_with_md5_hashed_password() {
+    let db_path = NamedTempFile::new().expect("Creating temp file");
+    let db_path = db_path.path().to_string_lossy().to_string();
+    let old_password = "old password";
+    let new_password = "new password";
+
+    cli_create_user(&db_path, "bob", old_password);
+
+    cargo_bin_cmd!("korrosync")
+        .args([
+            "--db-path",
+            &db_path,
+            "user",
+            "reset-password",
+            "--username",
+            "bob",
+            "--password",
+            new_password,
+        ])
+        .assert()
+        .success();
+
+    let sync = Arc::new(
+        KorrosyncServiceRedb::new(&db_path).expect("Failed to open database created by the CLI"),
+    );
+    let app = app(AppState { sync });
+
+    let response = app
+        .oneshot(
+            AuthenticatedRequestBuilder::get("/users/auth")
+                .credentials("bob", &md5_hex(new_password))
+                .build(),
+        )
+        .await
+        .expect("Failed to send request");
+    assert_eq!(StatusCode::OK, response.status());
+}
+
+#[tokio::test]
+async fn cli_created_user_matches_equivalent_api_registration() {
+    let real_password = "same real password";
+
+    // CLI path: the admin types the real password directly.
+    let cli_db_path = NamedTempFile::new().expect("Creating temp file");
+    let cli_db_path = cli_db_path.path().to_string_lossy().to_string();
+    cli_create_user(&cli_db_path, "carol", real_password);
+    let cli_sync = Arc::new(
+        KorrosyncServiceRedb::new(&cli_db_path)
+            .expect("Failed to open database created by the CLI"),
+    );
+    let cli_app = app(AppState { sync: cli_sync });
+
+    // API path: a real client MD5-hashes the password before ever calling /users/create.
+    let api_db_path = NamedTempFile::new().expect("Creating temp file");
+    let api_sync = Arc::new(
+        KorrosyncServiceRedb::new(&api_db_path).expect("Failed to create KorrosyncService"),
+    );
+    let api_app = app(AppState { sync: api_sync });
+    let register_body = serde_json::json!({
+        "username": "carol",
+        "password": md5_hex(real_password),
+    })
+    .to_string();
+    let response = api_app
+        .clone()
+        .oneshot(
+            UnauthenticatedRequestBuilder::post("/users/create")
+                .json_body(&register_body)
+                .build(),
+        )
+        .await
+        .expect("Failed to send request");
+    assert_eq!(StatusCode::CREATED, response.status());
+
+    // Both accounts must authenticate identically when a real client sends MD5(real_password).
+    let key = md5_hex(real_password);
+
+    let cli_response = cli_app
+        .oneshot(
+            AuthenticatedRequestBuilder::get("/users/auth")
+                .credentials("carol", &key)
+                .build(),
+        )
+        .await
+        .expect("Failed to send request");
+    assert_eq!(StatusCode::OK, cli_response.status());
+
+    let api_response = api_app
+        .oneshot(
+            AuthenticatedRequestBuilder::get("/users/auth")
+                .credentials("carol", &key)
+                .build(),
+        )
+        .await
+        .expect("Failed to send request");
+    assert_eq!(StatusCode::OK, api_response.status());
+}


### PR DESCRIPTION
Fixes #130

## Summary
- kosync clients (KOReader, CrossPoint, etc.) always MD5-hash the password
  client-side before sending it, both at registration (`POST /users/create`)
  and at login (`x-auth-key` header). The server just Argon2-hashes whatever
  string it receives, so it never needs to know this is happening — as long
  as both the stored value and the login value went through the same
  transform.
- `korrosync user create` / `korrosync user reset-password` took the admin's
  typed password literally and Argon2-hashed it as-is, skipping the MD5 step
  a real client always performs. That meant CLI-created accounts stored
  `Argon2(password)` while every real client would send `MD5(password)` as
  `x-auth-key` — so login always failed with `401 Unauthorized`, even with
  the correct password.
- Added `korrosync::model::md5_hex`, and the CLI now runs the typed password
  through it before hashing, so CLI-created/reset accounts store the same
  credential a client-driven `POST /users/create` call would produce for the
  same password.

## Test plan
- [x] `src/model/user.rs`: unit tests for `md5_hex` (RFC 1321 known-answer
      vector, determinism, distinctness)
- [x] `tests/user_cli_password_test.rs` (new): spawns the real `korrosync`
      binary to run `user create` / `user reset-password`, then verifies
      login succeeds with the MD5-hashed key a real client sends and fails
      with the raw plaintext password; also verifies a CLI-created account
      and an API-registered account authenticate identically given the same
      real password
- [x] `cargo test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`
- [x] Manually verified against a running server with `curl` (MD5-hashed
      `x-auth-key` → `200 OK`, raw plaintext `x-auth-key` → `401`)